### PR TITLE
docs: add architecture decisions for alpha scope (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ This project is licensed under the GNU General Public License v3.0 only — see 
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow, commit hygiene, and review expectations.
 
+## Architecture
+
+Architecture decisions for the alpha release (26.1.0-alpha.1) are documented as ADRs in [`docs/architecture/`](docs/architecture/):
+
+| ADR | Description |
+|-----|-------------|
+| [0001-alpha-foundation-scope.md](docs/architecture/0001-alpha-foundation-scope.md) | Alpha scope definition: in-scope/out-of-scope items, reusable foundations focus |
+| [0002-modular-monolith-first.md](docs/architecture/0002-modular-monolith-first.md) | Why modular monolith (not microservices), module boundaries, graduation criteria |
+| [0003-sqlite-local-first-storage.md](docs/architecture/0003-sqlite-local-first-storage.md) | SQLite as primary storage, local-first principles, storage graduation criteria |
+
+These documents define the project's technical direction and are used to evaluate feature requests. If a proposal conflicts with these decisions, it may be rejected with a pointer to the relevant ADR.
+
 ## Security
 
 See [SECURITY.md](SECURITY.md) for vulnerability reporting and current pre-production posture.

--- a/docs/architecture/0001-alpha-foundation-scope.md
+++ b/docs/architecture/0001-alpha-foundation-scope.md
@@ -1,0 +1,93 @@
+# Alpha Foundation Scope
+
+**Date**: 2026-04-30
+**Status**: Active
+**Milestone**: 26.1.0-alpha.1
+**Phase**: 0-governance
+
+## Objective
+
+Define the boundaries of the alpha release (26.1.0-alpha.1) to prevent scope explosion and keep the project focused on reusable foundations.
+
+## In-Scope
+
+The alpha focuses on **reusable foundations**, not vertical market solutions. The following areas are in-scope:
+
+### Kernel Core
+- Boot process and initialization
+- Process/micro-service management
+- Local-first data handling primitives
+- Minimal syscall interface
+
+### Storage Foundation
+- SQLite as primary local storage engine
+- FTS5 full-text search infrastructure
+- Backup and restore primitives
+- Database maintenance commands
+
+### Security Foundation
+- Role-Based Access Control (RBAC) policy framework
+- Development identity and authorization interfaces
+- Security policy enforcement points
+
+### Operations Foundation
+- Structured tracing infrastructure
+- Metrics collection
+- Health check endpoints
+- Timeline and relationship neighborhood services
+
+### Documentation
+- Architecture decision records (this document series)
+- Developer documentation
+- Operations documentation
+- Demo seed data and scenarios
+
+## Out-of-Scope
+
+The following items are **explicitly out-of-scope** for the alpha release. Feature requests for these areas should be rejected with a pointer to this document:
+
+### Vertical Market Features
+- Industry-specific workflows (healthcare, finance, education, etc.)
+- Domain-specific data models beyond generic primitives
+- Specialized UI/UX for specific user personas
+
+### Advanced Distributed Systems
+- Multi-node clustering
+- Consensus algorithms
+- Distributed consensus or coordination
+- Cloud synchronization (beyond local-first export/import)
+
+### Production Hardening
+- High availability configurations
+- Live migration of services
+- Advanced performance optimization
+- Enterprise integration patterns
+
+### External Integrations
+- Third-party API integrations
+- Cloud provider SDKs
+- External authentication providers (OAuth, SAML, etc.)
+- Social login or identity federation
+
+## Scope Evaluation Criteria
+
+When evaluating new feature requests, ask:
+
+1. **Is this a reusable foundation?** If it's specific to a vertical market, reject.
+2. **Does this block other in-scope work?** If not, defer to post-alpha.
+3. **Can this be built as a module on top of foundations?** If yes, it's out-of-scope for alpha.
+
+## Rejection Template
+
+When rejecting out-of-scope requests, use this template:
+
+```
+Thank you for the suggestion. This feature falls outside the alpha scope defined in 
+[docs/architecture/0001-alpha-foundation-scope.md](../docs/architecture/0001-alpha-foundation-scope.md). 
+
+The alpha (26.1.0-alpha.1) focuses on reusable foundations, not vertical market solutions. 
+This feature appears to be [vertical-specific / production-hardening / distributed-systems / integration].
+
+We plan to revisit this area after the alpha foundations are stable. Feel free to open an 
+issue labeled `post-alpha` to track it for future consideration.
+```

--- a/docs/architecture/0002-modular-monolith-first.md
+++ b/docs/architecture/0002-modular-monolith-first.md
@@ -1,0 +1,79 @@
+# Modular Monolith First
+
+**Date**: 2026-04-30
+**Status**: Active
+**Milestone**: 26.1.0-alpha.1
+**Phase**: 0-governance
+
+## Decision
+
+The initial implementation of dotlanth will be a **modular monolith**, not a microservices architecture.
+
+## Context
+
+dotlanth is a local-first OS kernel that must operate with minimal external dependencies. The project is in alpha (26.1.0-alpha.1) with a focus on reusable foundations.
+
+## Why NOT Microservices
+
+### 1. Local-First Constraints
+- Microservices typically require network communication, service discovery, and orchestration
+- A local-first system should minimize runtime dependencies and network assumptions
+- Inter-process communication (IPC) adds complexity without benefit for single-node operation
+
+### 2. Operational Simplicity
+- Single deployment unit vs. managing multiple service lifecycles
+- No need for service mesh, distributed tracing, or distributed configuration
+- Easier debugging and development workflow
+
+### 3. Data Consistency
+- Local-first systems benefit from SQLite's ACID transactions across "modules"
+- Microservices would require distributed transaction patterns (Saga, 2PC) or eventual consistency
+- Single database simplifies the alpha scope
+
+### 4. Alpha Scope Alignment
+- The alpha focuses on reusable foundations, not distributed systems
+- Modular monolith delivers the same module boundaries with less infrastructure
+- Can extract services later if/when multi-node becomes a requirement
+
+## Modular Monolith Structure
+
+The codebase will be organized as independent modules with clear boundaries:
+
+```
+dotlanth/
+├── Cargo.toml                    # Workspace root
+├── crates/
+│   ├── dotlanth-kernel/          # Core kernel module
+│   ├── dotlanth-storage/         # Storage and FTS5 module
+│   ├── dotlanth-security/        # RBAC and auth module
+│   ├── dotlanth-search/          # Search services module
+│   └── dotlanth-ops/             # Operations and health module
+```
+
+### Module Communication
+- **In-process function calls** for synchronous operations
+- **Event bus (in-process)** for asynchronous notifications
+- **Well-defined trait boundaries** between modules
+- **No circular dependencies** between modules
+
+### Module Boundaries
+Each module:
+- Owns its data models and business logic
+- Exposes a trait-based API for other modules
+- May have its own SQLite tables (with table prefix)
+- Must not directly access another module's internal state
+
+## Graduation Criteria for Decomposition
+
+The modular monolith should be reconsidered when ANY of these become true:
+
+1. **Multi-node requirement**: When dotlanth needs to run across multiple machines
+2. **Independent scaling**: When different modules need different resource allocations
+3. **Technology heterogeneity**: When a module needs a different tech stack
+4. **Team scaling**: When multiple teams need independent deployment cycles
+
+Until then, the modular monolith provides the right balance of:
+- Clear module boundaries (for future extraction)
+- Operational simplicity (single deployment)
+- Data consistency (single database)
+- Developer productivity (easier debugging, testing, deployment)

--- a/docs/architecture/0003-sqlite-local-first-storage.md
+++ b/docs/architecture/0003-sqlite-local-first-storage.md
@@ -1,0 +1,100 @@
+# SQLite Local-First Storage
+
+**Date**: 2026-04-30
+**Status**: Active
+**Milestone**: 26.1.0-alpha.1
+**Phase**: 0-governance
+
+## Decision
+
+dotlanth will use **SQLite** as the primary local storage engine for the alpha release (26.1.0-alpha.1).
+
+## Context
+
+dotlanth is a local-first OS kernel. All core functionality must work offline without cloud dependencies. The alpha focuses on reusable foundations, not distributed systems.
+
+## Why SQLite
+
+### 1. Local-First Alignment
+- **Zero network dependencies**: SQLite is an embedded database
+- **Single file storage**: Easy to backup, restore, and transfer
+- **Cross-platform**: Works on all targets dotlanth supports
+- **Transactional**: Full ACID compliance for data integrity
+
+### 2. Developer Experience
+- **No server to manage**: The database is just a file
+- **Standard tooling**: Any SQLite client can inspect the data
+- **FTS5 support**: Built-in full-text search for the search module
+- **WAL mode**: Good concurrent read performance
+
+### 3. Alpha Scope Fit
+- Sufficient for single-node operation (the alpha focus)
+- Supports the modular monolith architecture (single database, multiple table prefixes)
+- Can be replaced later without changing the application interface (trait-based storage)
+
+## Local-First Architecture Principles
+
+### Data Sovereignty
+- All data lives on the user's device
+- Users can inspect, backup, and restore their data using standard tools
+- No data leaves the device unless explicitly configured (post-alpha feature)
+
+### Offline Capability
+- All core operations work without network connectivity
+- The system degrades gracefully when offline (which is the default state)
+- Sync/export features (post-alpha) are additive, not required
+
+### Minimal Dependencies
+- SQLite is embedded, not a separate service
+- No external database server to install, configure, or secure
+- Single binary + database file = complete system
+
+## Storage Interface
+
+The storage module will expose a trait-based interface:
+
+```rust
+trait Storage {
+    fn query(&self, sql: &str) -> Result<Rows>;
+    fn execute(&self, sql: &str) -> Result<usize>;
+    fn transaction(&self) -> Result<Transaction>;
+}
+```
+
+This allows replacing SQLite with another engine (Postgres, etc.) by implementing the trait.
+
+## Storage Graduation Criteria
+
+SQLite is the starting point. The following graduation criteria indicate when to add/replace storage engines:
+
+### PostgreSQL
+**When**: Multi-node deployment becomes a requirement
+- Rationale: Need a shared database for distributed operation
+- Migration path: Implement `Storage` trait for PostgreSQL
+
+### Object Storage (S3-compatible, local filesystem)
+**When**: Large binary objects (blobs) exceed SQLite's comfort zone (>1GB blobs)
+- Rationale: SQLite is not optimized for large binary storage
+- Migration path: Blob storage trait + SQLite metadata references
+
+### Event Streaming (Kafka, NATS, etc.)
+**When**: Inter-node event propagation needed for distributed operation
+- Rationale: SQLite cannot serve as an event log for multiple nodes
+- Migration path: Event streaming module + local SQLite read models
+
+### Analytical Storage (ClickHouse, DuckDB, etc.)
+**When**: OLAP queries slow down the transactional database
+- Rationale: Separate analytical workloads from OLTP
+- Migration path: ETL pipeline from SQLite to analytical store
+
+### Specialized Search (Elasticsearch, Meilisearch, etc.)
+**When**: FTS5 capabilities are insufficient (complex rankings, faceted search, etc.)
+- Rationale: FTS5 covers basic search; specialized engines for advanced features
+- Migration path: Search module implements adapter for specialized engine
+
+## Migration Principles
+
+1. **Trait-based abstraction**: Storage interface remains stable
+2. **Gradual migration**: Can run multiple storage engines side-by-side
+3. **No forced upgrades**: Users can stay on SQLite as long as it meets their needs
+4. **Backwards compatibility**: Migration tools preserve data integrity


### PR DESCRIPTION
Add three ADRs to define alpha scope and prevent scope explosion:
- 0001-alpha-foundation-scope.md: in-scope/out-of-scope items
- 0002-modular-monolith-first.md: why modular monolith, not microservices
- 0003-sqlite-local-first-storage.md: SQLite as primary storage, graduation criteria

Update README.md with Architecture section linking to the ADRs.